### PR TITLE
Mitigate single dash long flags

### DIFF
--- a/app.go
+++ b/app.go
@@ -209,7 +209,7 @@ func (a *Application) parseContext(ignoreDefault bool, args []string) (*ParseCon
 // on.
 func (a *Application) Parse(args []string) (command string, err error) {
 	context, parseErr := a.ParseContext(args)
-	selected := []string{}
+	var selected []string
 	var setValuesErr error
 
 	if context == nil {

--- a/flags.go
+++ b/flags.go
@@ -147,7 +147,12 @@ func (f *flagGroup) parse(context *ParseContext) (*FlagClause, error) {
 					context.Elements = context.Elements[:len(context.Elements)-pos]
 					for x := len(current) - pos - 1; x > 0; x-- {
 						// We skip all remaining elements of the group
-						context.Next()
+						purgedToken := context.Next()
+						// That's not suppose to be possible, but let's add it either way
+						if purgedToken.Type == TokenLong {
+							err = fmt.Errorf("while skipping unmanaged shorts flags, skipped long flag '%s' from '%s'", purgedToken.Value, current)
+							return nil, err
+						}
 					}
 				}
 				context.appUnmanagedArgs.Unmanaged = append(context.appUnmanagedArgs.Unmanaged, current)

--- a/flags.go
+++ b/flags.go
@@ -148,7 +148,7 @@ func (f *flagGroup) parse(context *ParseContext) (*FlagClause, error) {
 					for x := len(current) - pos - 1; x > 0; x-- {
 						// We skip all remaining elements of the group
 						purgedToken := context.Next()
-						// That's not suppose to be possible, but let's add it either way
+						// This error isn't supposed to be possible, but let's handle it anyway.
 						if purgedToken.Type == TokenLong {
 							err = fmt.Errorf("while skipping unmanaged shorts flags, skipped long flag '%s' from '%s'", purgedToken.Value, current)
 							return nil, err

--- a/parser.go
+++ b/parser.go
@@ -192,7 +192,7 @@ func (p *ParseContext) Next() *Token {
 		return p.Next()
 	}
 
-	if strings.HasPrefix(arg, "--") {
+	if strings.HasPrefix(arg, "--") || (strings.HasPrefix(arg, "-") && strings.Count(arg, "-") > 1) {
 		parts := strings.SplitN(arg[2:], "=", 2)
 		token := &Token{p.argi, TokenLong, parts[0]}
 		if len(parts) == 2 {

--- a/parser_test.go
+++ b/parser_test.go
@@ -120,3 +120,57 @@ func TestParseContextPush(t *testing.T) {
 	b = c.Next()
 	assert.Equal(t, "bar", b.Value)
 }
+
+func TestAppParseSingleThenDoubleDashFlags(t *testing.T) {
+	app := New("test", "")
+	app.allowUnmanaged = true
+	app.Command("foo", "")
+
+	_, err := app.ParseContext([]string{"foo", "-single-dash", "--double-dash"})
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"-single-dash", "--double-dash"}, app.Unmanaged)
+}
+
+func TestAppParseTwoSingleDashFlags(t *testing.T) {
+	app := New("test", "")
+	app.allowUnmanaged = true
+	app.Command("foo", "")
+
+	_, err := app.ParseContext([]string{"foo", "-short-flag", "-verylongshort-flag"})
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"-short-flag", "-verylongshort-flag"}, app.Unmanaged)
+}
+
+func TestAppParseDoubleThenSingleDashFlags(t *testing.T) {
+	app := New("test", "")
+	app.allowUnmanaged = true
+	app.Command("foo", "")
+
+	_, err := app.ParseContext([]string{"foo", "--double-dash", "-single-dash"})
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"--double-dash", "-single-dash"}, app.Unmanaged)
+}
+
+func TestAppParseVerboseVarFlags(t *testing.T) {
+	app := New("test", "")
+	app.allowUnmanaged = true
+	app.Command("foo", "")
+	app.Flag("verbose", "").Short('v').Bool()
+
+	_, err := app.ParseContext([]string{"foo", "-v", "-var"})
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"-var"}, app.Unmanaged)
+}
+
+func TestAppParseVerboseVarWithoutTheFlag(t *testing.T) {
+	app := New("test", "")
+	app.allowUnmanaged = true
+	app.Command("foo", "")
+	app.Flag("verbose", "").Short('v').Bool()
+	app.Flag("aflag", "").Short('a').Bool()
+	// app.Flag("rflag", "").Short('r').Bool()
+
+	_, err := app.ParseContext([]string{"foo", "-var"})
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"-var"}, app.Unmanaged)
+}

--- a/parser_test.go
+++ b/parser_test.go
@@ -162,13 +162,12 @@ func TestAppParseVerboseVarFlags(t *testing.T) {
 	assert.Equal(t, []string{"-var"}, app.Unmanaged)
 }
 
-func TestAppParseVerboseVarWithoutTheFlag(t *testing.T) {
+func TestAppParseUnmanagedVarWithTwoManagedFlags(t *testing.T) {
 	app := New("test", "")
 	app.allowUnmanaged = true
 	app.Command("foo", "")
 	app.Flag("verbose", "").Short('v').Bool()
 	app.Flag("aflag", "").Short('a').Bool()
-	// app.Flag("rflag", "").Short('r').Bool()
 
 	_, err := app.ParseContext([]string{"foo", "-var"})
 	assert.Nil(t, err)


### PR DESCRIPTION
Fixes the use of "long short flags" that exist in some applications like Terraform's `-auto-approve`. 

Before it would read `-auto-approve` as `-a -u -t -o` and fail at the middle `-` because it would find a long flag `--approve`. Now we catch those cases and handle them.