### PR TITLE
Fix long short flags parsing and test

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -193,7 +193,12 @@ func (p *ParseContext) Next() *Token {
 	}
 
 	if strings.HasPrefix(arg, "--") || (strings.HasPrefix(arg, "-") && strings.Count(arg, "-") > 1) {
-		parts := strings.SplitN(arg[2:], "=", 2)
+		var parts []string
+		if strings.HasPrefix(arg, "--") {
+			parts = strings.SplitN(arg[2:], "=", 2)
+		} else {
+			parts = strings.SplitN(arg[1:], "=", 2)
+		}
 		token := &Token{p.argi, TokenLong, parts[0]}
 		if len(parts) == 2 {
 			p.Push(&Token{p.argi, TokenArg, parts[1]})

--- a/parser_test.go
+++ b/parser_test.go
@@ -173,3 +173,14 @@ func TestAppParseUnmanagedVarWithTwoManagedFlags(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"-var"}, app.Unmanaged)
 }
+
+func TestAppParseShortLongFlags(t *testing.T) {
+	app := New("test", "")
+	app.allowUnmanaged = true
+	app.Command("foo", "")
+	app.Flag("verbose-level", "").Short('v').Bool()
+
+	ctx, err := app.ParseContext([]string{"foo", "-verbose-level"})
+	assert.Nil(t, err)
+	assert.Len(t, ctx.Elements, 2)
+}


### PR DESCRIPTION
I forgot something and it would make for some nasty bug.

In image:
![image](https://user-images.githubusercontent.com/18617578/221866424-948c4e58-d596-4ccf-b4f2-3adb37fcd591.png)

tl;dr
when we parsed the part after the dash in the short long flag, we would remove the dash and the first char instead of just the dash.